### PR TITLE
Allow setting nil values

### DIFF
--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -8,8 +8,10 @@ module ActiveRecordUpsert
         values = run_callbacks(:save) {
           run_callbacks(:create) {
             attribute_names ||= changed
-            attribute_names = attribute_names.map(&:to_s) + ['created_at', 'updated_at']
-            _upsert_record(attribute_names)
+            attribute_names = attribute_names.map(&:to_s) +
+              timestamp_attributes_for_create_in_model +
+              timestamp_attributes_for_update_in_model
+            _upsert_record(attribute_names.uniq)
           }
         }
         assign_attributes(values.first.to_h)

--- a/spec/active_record/base_spec.rb
+++ b/spec/active_record/base_spec.rb
@@ -41,6 +41,14 @@ module ActiveRecord
           upserted.upsert
           expect(upserted.name).to eq('somename')
         end
+
+        context 'when specifying attributes' do
+          it 'sets all the specified attributes' do
+            upserted = MyRecord.new(id: key)
+            upserted.upsert([:id, :name])
+            expect(upserted.name).to eq(nil)
+          end
+        end
       end
 
       context 'when the record is not new' do
@@ -48,6 +56,20 @@ module ActiveRecord
           record = MyRecord.create(name: 'somename')
           record.save
           expect { record.upsert }.to raise_error(RecordSavedError)
+        end
+      end
+    end
+
+    describe '.upsert' do
+      context 'when the record already exists' do
+        let(:key) { 1 }
+        let(:attributes) { {id: key, name: 'othername', wisdom: nil} }
+        before { MyRecord.create(id: key, name: 'somename', wisdom: 2) }
+
+        it 'updates all passed attributes' do
+          record = MyRecord.upsert(attributes)
+          expect(record.name).to eq(attributes[:name])
+          expect(record.wisdom).to eq(attributes[:wisdom])
         end
       end
 


### PR DESCRIPTION
Currently nil values are not set in the upsert, since they don't appear in the changed array of a new object. However, an update can need to set values to nil.

This allows passing an array of attributes to be update to #upsert; and, when calling .upsert, sets all the values in the supplied hash.