### PR TITLE
Create record with all initialized attributes

### DIFF
--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -24,9 +24,9 @@ module ActiveRecordUpsert
       end
 
 
-      def _upsert_record(attribute_names = changed, wheres = [])
-        attributes_values = arel_attributes_with_values_for_create(attribute_names)
-        values = self.class.unscoped.upsert(attributes_values, wheres)
+      def _upsert_record(upsert_attribute_names = changed, wheres = [])
+        existing_attributes = arel_attributes_with_values_for_create(self.attributes.keys)
+        values = self.class.unscoped.upsert(existing_attributes, upsert_attribute_names, wheres)
         @new_record = false
         values
       end

--- a/spec/active_record/base_spec.rb
+++ b/spec/active_record/base_spec.rb
@@ -17,6 +17,12 @@ module ActiveRecord
           expect(record.created_at).not_to be_nil
           expect(record.updated_at).not_to be_nil
         end
+
+        it 'updates only given attributes' do
+          record = MyRecord.new(id: 25, name: 'Some name', wisdom: 3)
+          record.upsert(attributes: [:id, :name])
+          expect(record.reload.wisdom).to eq(3)
+        end
       end
 
       context 'when the record already exists' do


### PR DESCRIPTION
Allows you to create record with all the values you need, but upsert only needed attributes:
```ruby
record = SomeRecord.new(id: 25, attr1: "foo", attr2: "bar")
record.upsert(attributes: [:attr1])
```
In this example, if the record does not exist, it will be created with `id`, `attr1`, `attr2` set.
But if it exists (and triggers `ON CONFLICT` handler), it will only update `attr1`.