### PR TITLE
Fix updating updated_at during upsert for ActiveRecord 5.0

### DIFF
--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -9,10 +9,10 @@ module ActiveRecordUpsert
         values = run_callbacks(:save) {
           run_callbacks(:create) {
             attributes ||= changed
-            attributes = attributes.map(&:to_s) +
+            attributes = attributes +
               timestamp_attributes_for_create_in_model +
               timestamp_attributes_for_update_in_model
-            _upsert_record(attributes.uniq, where)
+            _upsert_record(attributes.map(&:to_s).uniq, where)
           }
         }
         assign_attributes(values.first.to_h)

--- a/spec/active_record/base_spec.rb
+++ b/spec/active_record/base_spec.rb
@@ -28,11 +28,12 @@ module ActiveRecord
       context 'when the record already exists' do
         let(:key) { 1 }
         before { MyRecord.create(id: key, name: 'somename') }
+
         it 'sets the updated_at timestamp' do
           first_updated_at = MyRecord.find(key).updated_at
           upserted = MyRecord.new(id: key)
           upserted.upsert
-          expect(upserted.updated_at).to be > first_updated_at
+          expect(upserted.reload.updated_at).to be > first_updated_at
         end
 
         it 'does not reset the created_at timestamp' do
@@ -90,12 +91,18 @@ module ActiveRecord
       context 'when the record already exists' do
         let(:key) { 1 }
         let(:attributes) { {id: key, name: 'othername', wisdom: nil} }
-        let!(:existing) { MyRecord.create(id: key, name: 'somename', wisdom: 2) }
+        let(:existing_updated_at) { Time.new(2017, 1, 1) }
+        let!(:existing) { MyRecord.create(id: key, name: 'somename', wisdom: 2, updated_at: existing_updated_at) }
 
         it 'updates all passed attributes' do
           record = MyRecord.upsert(attributes)
           expect(record.name).to eq(attributes[:name])
           expect(record.wisdom).to eq(attributes[:wisdom])
+        end
+
+        it 'sets the updated_at timestamp' do
+          record = MyRecord.upsert(attributes)
+          expect(record.reload.updated_at).to be > existing_updated_at
         end
 
         context 'with conditions' do
@@ -109,6 +116,7 @@ module ActiveRecord
             expect {
               MyRecord.upsert(attributes, where: [MyRecord.arel_table[:wisdom].lt(3)])
             }.to change { existing.reload.wisdom }.to(nil)
+            expect(existing.reload.updated_at).to be > existing_updated_at
           end
         end
       end


### PR DESCRIPTION
ActiveRecord 5.0.x: `ActiveRecord::Timestamp`:
```ruby
def timestamp_attributes_for_update
  [:updated_at, :updated_on]
end
```
ActiveRecord 5.1.x: `ActiveRecord::Timestamp`:

```ruby
def timestamp_attributes_for_update
  ["updated_at", "updated_on"]
end
```