### PR TITLE
Add “where:” option for upsert_keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ r.upsert
 # => #<Vehicle id: 1, make: 'Ford', name: 'Focus', doors: 2>
 ```
 
+Partial indexes can be supported with the addition of a `where` clause.
+
+```ruby
+class Account < ApplicationRecord
+  upsert_keys :name, where: 'active is TRUE'
+end
+```
+
 ## Tests
 
 Make sure to have an upsert_test database:

--- a/lib/active_record_upsert/active_record/persistence.rb
+++ b/lib/active_record_upsert/active_record/persistence.rb
@@ -52,8 +52,14 @@ module ActiveRecordUpsert
 
         def upsert_keys(*keys)
           return @_upsert_keys if keys.empty?
+          options = keys.extract_options!
           keys = keys.first if keys.size == 1 # support single string/symbol, multiple string/symbols, and array
           @_upsert_keys = Array(keys).map(&:to_s)
+          @_upsert_options = options
+        end
+
+        def upsert_options
+          @_upsert_options || {}
         end
       end
     end

--- a/lib/active_record_upsert/active_record/relation.rb
+++ b/lib/active_record_upsert/active_record/relation.rb
@@ -13,6 +13,7 @@ module ActiveRecordUpsert
 
         on_conflict_do_update = arel_table.create_on_conflict_do_update
         on_conflict_do_update.target = arel_table[upsert_keys.join(',')]
+        on_conflict_do_update.target_condition = self.klass.upsert_options[:where]
         on_conflict_do_update.wheres = wheres
         on_conflict_do_update.set(vals_for_upsert)
 

--- a/lib/active_record_upsert/arel/nodes/on_conflict.rb
+++ b/lib/active_record_upsert/arel/nodes/on_conflict.rb
@@ -1,12 +1,13 @@
 module Arel
   module Nodes
     class OnConflict < Node
-      attr_accessor :target, :action
+      attr_accessor :target, :where, :action
 
       def initialize
         super
         @target = nil
         @action = nil
+        @where = nil
       end
 
       def hash

--- a/lib/active_record_upsert/arel/on_conflict_do_update_manager.rb
+++ b/lib/active_record_upsert/arel/on_conflict_do_update_manager.rb
@@ -8,6 +8,10 @@ module Arel
       @ctx = @ast
     end
 
+    def target_condition= where
+      @ast.where = where
+    end
+
     def target= column
       @ast.target = column
     end

--- a/lib/active_record_upsert/arel/visitors/to_sql.rb
+++ b/lib/active_record_upsert/arel/visitors/to_sql.rb
@@ -14,6 +14,7 @@ module ActiveRecordUpsert
         def visit_Arel_Nodes_OnConflict o, collector
           collector << "ON CONFLICT "
           collector << " (#{quote_column_name o.target.name}) ".gsub(',', '","')
+          collector << " WHERE #{o.where}" if o.where
           maybe_visit o.action, collector
         end
 

--- a/spec/active_record/base_spec.rb
+++ b/spec/active_record/base_spec.rb
@@ -83,13 +83,13 @@ module ActiveRecord
         before { Account.create(name: 'somename', active: true) }
 
         context 'when the record matches the partial index' do
-          it 'raises an error' do
+          it 'does not create a new record' do
             expect{ Account.upsert!(name: 'somename', active: true) }.not_to change{ Account.count }.from(1)
           end
         end
 
         context 'when the record does meet the where clause' do
-          it 'raises an error' do
+          it 'creates a new record' do
             expect{ Account.upsert!(name: 'somename', active: false) }.to change{ Account.count }.from(1).to(2)
           end
         end

--- a/spec/active_record/base_spec.rb
+++ b/spec/active_record/base_spec.rb
@@ -78,6 +78,22 @@ module ActiveRecord
           expect { record.upsert(validate: false) }.to change{ Vehicle.count }.by(1)
         end
       end
+
+      context "when supporting a partial index" do
+        before { Account.create(name: 'somename', active: true) }
+
+        context 'when the record matches the partial index' do
+          it 'raises an error' do
+            expect{ Account.upsert!(name: 'somename', active: true) }.not_to change{ Account.count }.from(1)
+          end
+        end
+
+        context 'when the record does meet the where clause' do
+          it 'raises an error' do
+            expect{ Account.upsert!(name: 'somename', active: false) }.to change{ Account.count }.from(1).to(2)
+          end
+        end
+      end
     end
 
     describe '#upsert!' do

--- a/spec/dummy/app/models/account.rb
+++ b/spec/dummy/app/models/account.rb
@@ -1,0 +1,3 @@
+class Account < ApplicationRecord
+  upsert_keys :name, where: 'active is TRUE'
+end

--- a/spec/dummy/db/migrate/20160419124140_create_accounts.rb
+++ b/spec/dummy/db/migrate/20160419124140_create_accounts.rb
@@ -1,0 +1,11 @@
+class CreateAccounts < ActiveRecord::Migration[5.0]
+  def change
+    create_table :accounts do |t|
+      t.string :name
+      t.boolean :active
+      t.timestamps
+    end
+
+     add_index :accounts, :name, unique: true, where: "active IS TRUE"
+  end
+end

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -27,6 +27,38 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
+-- Name: accounts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE accounts (
+    id integer NOT NULL,
+    name character varying,
+    active boolean,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: accounts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE accounts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: accounts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE accounts_id_seq OWNED BY accounts.id;
+
+
+--
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -87,6 +119,7 @@ CREATE TABLE vehicles (
     id integer NOT NULL,
     wheels_count integer,
     name character varying,
+    make character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );
@@ -112,21 +145,36 @@ ALTER SEQUENCE vehicles_id_seq OWNED BY vehicles.id;
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: accounts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY accounts ALTER COLUMN id SET DEFAULT nextval('accounts_id_seq'::regclass);
+
+
+--
+-- Name: my_records id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY my_records ALTER COLUMN id SET DEFAULT nextval('my_records_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: vehicles id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY vehicles ALTER COLUMN id SET DEFAULT nextval('vehicles_id_seq'::regclass);
 
 
 --
--- Name: ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: accounts accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY accounts
+    ADD CONSTRAINT accounts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY ar_internal_metadata
@@ -134,7 +182,7 @@ ALTER TABLE ONLY ar_internal_metadata
 
 
 --
--- Name: my_records_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: my_records my_records_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY my_records
@@ -142,7 +190,7 @@ ALTER TABLE ONLY my_records
 
 
 --
--- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY schema_migrations
@@ -150,11 +198,18 @@ ALTER TABLE ONLY schema_migrations
 
 
 --
--- Name: vehicles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: vehicles vehicles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY vehicles
     ADD CONSTRAINT vehicles_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: index_accounts_on_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_accounts_on_name ON accounts USING btree (name) WHERE (active IS TRUE);
 
 
 --
@@ -165,6 +220,13 @@ CREATE UNIQUE INDEX index_my_records_on_wisdom ON my_records USING btree (wisdom
 
 
 --
+-- Name: index_vehicles_on_make_and_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_vehicles_on_make_and_name ON vehicles USING btree (make, name);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -172,6 +234,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20160419103547'),
-('20160419124138');
+('20160419124138'),
+('20160419124140');
 
 


### PR DESCRIPTION
Adds a `:where` keyword argument for the `upsert_keys` configuration. 